### PR TITLE
Bump unbound from 1.24.1 to 1.25.0

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
 
   unbound:
     container_name: unbound
-    image: "klutchell/unbound:1.24.1"
+    image: "klutchell/unbound:1.25.0"
     volumes:
       - ./unbound/unbound.conf:/opt/unbound/etc/unbound/unbound.conf:ro
     networks:


### PR DESCRIPTION
## Summary
- Updates the Unbound DNS resolver image from `1.24.1` to `1.25.0` in `compose.yaml`