### PR TITLE
pin Home Assistant image to homeassistant/home-assistant:2026.5

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   homeassistant:
     container_name: homeassistant
-    image: "ghcr.io/home-assistant/home-assistant:stable"
+    image: "homeassistant/home-assistant:2026.5"
     volumes:
       - /config_homeassistant:/config
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
## Summary
- Pin Home Assistant Docker image from `ghcr.io/home-assistant/home-assistant:stable` to `homeassistant/home-assistant:2026.5`