### PR TITLE
pin AdGuard Home image to adguard/adguardhome:v0.107.74

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
       - "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AB54UCXR-if00-port0:/dev/ttyUSB1"
 
   adguardhome:
-    image: adguard/adguardhome
+    image: adguard/adguardhome:v0.107.74
     container_name: adguardhome
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
- Pin AdGuard Home Docker image from `adguard/adguardhome` (latest) to `adguard/adguardhome:v0.107.74`